### PR TITLE
feat: Update for Keptn 0.19.x, minor GHA specific changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,16 @@ This repository contains GitHub Actions for installing and uninstalling Keptn in
 |:--------------:|:-----------------------------------------------------------------------------------------------:|
 |   0.15, 0.16   |                            keptn-sandbox/action-install-keptn@0.2.0                             |
 |     0.17.0     |                            keptn-sandbox/action-install-keptn@0.3.0                             |
+|     0.19.x     |                            keptn-sandbox/action-install-keptn@0.4.0                             |
 
 ### Install Keptn
 
 **Inputs**:
 * `KEPTN_VERSION`: The version of Keptn that should be installed (e.g. `0.13.1`)
-* `HELM_VALUES`: Helm values using during installation passed a properly formatted multiline YAML string.  Defaults to 
+* `HELM_VALUES`: Helm values used during installation passed as properly formatted multiline YAML string.  Defaults to 
 ```yaml
       apiGatewayNginx:
         type: LoadBalancer
-      continuousDelivery:
-        enabled: true
 ``` 
 * `KUBECONFIG`: The location of the kubernetes configuration file. Defaults to `$HOME/.kube/config`.
 * `UNINSTALL`: Set to `true` if the Keptn instance should be removed from the kubernetes cluster

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains GitHub Actions for installing and uninstalling Keptn in
 * `KEPTN_API_URL`: HTTP URL of the Keptn API endpoint. Could be empty if it was not possible to determine a KEPTN_ENDPOINT.
 * `KEPTN_API_TOKEN`: A API token needed for the communication with Keptn
 
-If the `control-plane.apiGatewayNginx.type` value is not `LoadBalancer` or `NodePort` the action does not return an endpoint since there's no way to determine an address (host:port pair) that would expose the Keptn api gateway to the outside of the kubernetes cluster.
+If the `apiGatewayNginx.type` value is not `LoadBalancer` or `NodePort` the action does not return an endpoint since there's no way to determine an address (host:port pair) that would expose the Keptn api gateway to the outside of the kubernetes cluster.
 
 In such cases please refer to the [relevant keptn documentation](https://keptn.sh/docs/0.16.x/operate/install/#access-options) for your keptn version.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This repository contains GitHub Actions for installing and uninstalling Keptn in
 
 | Keptn Version* | [action-install-keptn releases](https://github.com/keptn-sandbox/action-install-keptn/releases) |
 |:--------------:|:-----------------------------------------------------------------------------------------------:|
-|   0.15, 0.16   |                            keptn-sandbox/action-install-keptn@0.2.0                             |
-|     0.17.0     |                            keptn-sandbox/action-install-keptn@0.3.0                             |
-|     0.19.x     |                            keptn-sandbox/action-install-keptn@0.4.0                             |
+|   0.15, 0.16   |                            keptn-sandbox/action-install-keptn@v2.0.0                            |
+|     0.17.0     |                            keptn-sandbox/action-install-keptn@v3.0.0                            |
+|     0.19.x     |                            keptn-sandbox/action-install-keptn@v4.0.0                            |
 
 ### Install Keptn
 

--- a/action.yaml
+++ b/action.yaml
@@ -11,8 +11,6 @@ inputs:
     default: |-
       apiGatewayNginx:
         type: LoadBalancer
-      continuousDelivery:
-        enabled: true
   KEPTN_NAMESPACE:
     description: Kubernetes namespace where Keptn will be installed
     required: false
@@ -93,8 +91,8 @@ runs:
             ext_ip=$(kubectl -n ${{inputs.KEPTN_NAMESPACE}} get service api-gateway-nginx -o=jsonpath="{.status.loadBalancer.ingress[0].ip}")
             if [ "$ext_ip" != "" ]; then
               port=$(kubectl -n keptn get service api-gateway-nginx -o=jsonpath="{.spec.ports[?(@.name==\"http\")].port}")
-              echo "::set-output name=KEPTN_API_URL::"http://$ext_ip:$port/api""
-              echo "::set-output name=KEPTN_HTTP_ENDPOINT::"$ext_ip:$port""
+              echo "KEPTN_API_URL=http://$ext_ip:$port/api" >> "$GITHUB_OUTPUT"
+              echo "KEPTN_HTTP_ENDPOINT=$ext_ip:$port" >> "$GITHUB_OUTPUT"
               break
             fi
             sleep 1
@@ -115,8 +113,8 @@ runs:
           fi
 
           port=$(kubectl -n keptn get service api-gateway-nginx -o=jsonpath="{.spec.ports[?(@.name==\"http\")].port}")
-          echo "::set-output name=KEPTN_API_URL::"http://$ext_ip:$port/api""
-          echo "::set-output name=KEPTN_HTTP_ENDPOINT::"$ext_ip:$port""
+          echo "KEPTN_API_URL=http://$ext_ip:$port/api" >> "$GITHUB_OUTPUT"
+          echo "KEPTN_HTTP_ENDPOINT=$ext_ip:$port" >> "$GITHUB_OUTPUT"
         else
           echo "No external endpoint can be auto-detected for service type ${{ steps.detect_keptn_endpoint_type.outputs.endpoint_type }} "
           echo "Please refer to Keptn access options at https://keptn.sh/docs/0.16.x/operate/install/#access-options"


### PR DESCRIPTION
### This PR
- updates the action for Keptn 0.19.x support by removing the `continuousDelivery.enabled` value
- updates `set-output` calls to new github format with `>> $GITHUB_OUTPUT`